### PR TITLE
Add an option to allow configuration of the ILIAS root URI

### DIFF
--- a/classes/class.ilSEBAccessChecker.php
+++ b/classes/class.ilSEBAccessChecker.php
@@ -247,6 +247,12 @@ class ilSEBAccessChecker
             $query = '?' . $query;
         }
 
+        if ($this->conf->getIliasRootUri() !== '') {
+            $root_uri = new \ILIAS\Data\URI($this->conf->getIliasRootUri());
+            $protocol = $root_uri->getHost();
+            $port = $root_uri->getPort();
+            $host = $root_uri->getHost();
+        }
 
         return $protocol . "://" . $host . $port . $path . $query;
     }

--- a/classes/class.ilSEBConfig.php
+++ b/classes/class.ilSEBConfig.php
@@ -87,9 +87,9 @@ class ilSEBConfig
         return (bool) $this->conf['show_pax_username'];
     }
 
-    public function getAllowProtocolChange() : bool
+    public function getIliasRootUri() : string
     {
-        return (bool) $this->conf['allow_protocol_change'];
+        return (string) $this->conf['ilias_root_uri'];
     }
     
     /**
@@ -160,7 +160,7 @@ class ilSEBConfig
             'show_pax_pic',
             'show_pax_matriculation',
             'show_pax_username',
-            'allow_protocol_change'
+            'ilias_root_uri'
         );
         
         $r = 0;
@@ -239,20 +239,6 @@ class ilSEBConfig
         foreach ($keys_from_config as $key_from_config) {
             if ($key_from_browser === hash('sha256', $request_url . trim($key_from_config))) {
                 return true;
-            }
-        }
-
-        if ($this->getAllowProtocolChange() === true) {
-            $check_url = $request_url;
-            if (strpos($request_url, 'http:') === 0) {
-                $check_url = str_replace('http:', 'https:', $request_url);
-            } else if (strpos($request_url, 'https:') === 0) {
-                $check_url = str_replace('https:', 'http:', $request_url);
-            }
-            foreach ($keys_from_config as $key_from_config) {
-                if ($key_from_browser === hash('sha256', $check_url . trim($key_from_config))) {
-                    return true;
-                }
             }
         }
         

--- a/classes/class.ilSEBConfig.php
+++ b/classes/class.ilSEBConfig.php
@@ -86,6 +86,11 @@ class ilSEBConfig
     {
         return (bool) $this->conf['show_pax_username'];
     }
+
+    public function getAllowProtocolChange() : bool
+    {
+        return (bool) $this->conf['allow_protocol_change'];
+    }
     
     /**
      * @return string[]
@@ -154,7 +159,8 @@ class ilSEBConfig
             'activate_session_control',
             'show_pax_pic',
             'show_pax_matriculation',
-            'show_pax_username'
+            'show_pax_username',
+            'allow_protocol_change'
         );
         
         $r = 0;
@@ -233,6 +239,20 @@ class ilSEBConfig
         foreach ($keys_from_config as $key_from_config) {
             if ($key_from_browser === hash('sha256', $request_url . trim($key_from_config))) {
                 return true;
+            }
+        }
+
+        if ($this->getAllowProtocolChange() === true) {
+            $check_url = $request_url;
+            if (strpos($request_url, 'http:') === 0) {
+                $check_url = str_replace('http:', 'https:', $request_url);
+            } else if (strpos($request_url, 'https:') === 0) {
+                $check_url = str_replace('https:', 'http:', $request_url);
+            }
+            foreach ($keys_from_config as $key_from_config) {
+                if ($key_from_browser === hash('sha256', $check_url . trim($key_from_config))) {
+                    return true;
+                }
             }
         }
         

--- a/classes/class.ilSEBConfigGUI.php
+++ b/classes/class.ilSEBConfigGUI.php
@@ -126,6 +126,11 @@ class ilSEBConfigGUI extends ilPluginConfigGUI
         $show_pax_username_cb->setInfo($this->pl->txt('show_pax_username_info'));
         $show_pax_username_cb->setChecked($this->config->getShowPaxUsername());
         $form->addItem($show_pax_username_cb);
+
+        $allow_protocol_change_cb = new ilCheckboxInputGUI($this->pl->txt('allow_protocol_change'), 'allow_protocol_change');
+        $allow_protocol_change_cb->setInfo($this->pl->txt('allow_protocol_change_info'));
+        $allow_protocol_change_cb->setChecked($this->config->getAllowProtocolChange());
+        $form->addItem($allow_protocol_change_cb);
         
         $form->addCommandButton('save', $this->lang->txt('save'));
                     

--- a/classes/class.ilSEBConfigGUI.php
+++ b/classes/class.ilSEBConfigGUI.php
@@ -33,6 +33,7 @@ class ilSEBConfigGUI extends ilPluginConfigGUI
     private $lang;
     private $ctrl;
     private $rbac_review;
+    private $http;
     
     public function performCommand($cmd)
     {
@@ -46,6 +47,7 @@ class ilSEBConfigGUI extends ilPluginConfigGUI
                 $this->lang = $DIC->language();
                 $this->ctrl = $DIC->ctrl();
                 $this->rbac_review = $DIC->rbac()->review();
+                $this->http = $DIC->http();
                 $this->$cmd();
                 break;
 
@@ -127,11 +129,17 @@ class ilSEBConfigGUI extends ilPluginConfigGUI
         $show_pax_username_cb->setChecked($this->config->getShowPaxUsername());
         $form->addItem($show_pax_username_cb);
 
-        $allow_protocol_change_cb = new ilCheckboxInputGUI($this->pl->txt('allow_protocol_change'), 'allow_protocol_change');
-        $allow_protocol_change_cb->setInfo($this->pl->txt('allow_protocol_change_info'));
-        $allow_protocol_change_cb->setChecked($this->config->getAllowProtocolChange());
-        $form->addItem($allow_protocol_change_cb);
-        
+        $ilias_root_txt = new ilTextInputGUI($this->pl->txt("ilias_root_uri"), "ilias_root_uri");
+        $ilias_root_txt->setInfo($this->pl->txt("ilias_root_uri_info"));
+        $ilias_root_txt->setMaxLength(1000);
+        if ($this->config->getIliasRootUri() !== '') {
+            $ilias_root_txt->setValue($this->config->getIliasRootUri());
+        } else {
+            $uri = $this->http->request()->getUri();
+            $ilias_root_txt->setValue($uri->getScheme() . "://" . $uri->getHost() . $uri->getPort());
+        }
+        $form->addItem($ilias_root_txt);
+
         $form->addCommandButton('save', $this->lang->txt('save'));
                     
         $form->setTitle($this->pl->txt('config'));
@@ -154,6 +162,7 @@ class ilSEBConfigGUI extends ilPluginConfigGUI
             $form_input['show_pax_pic'] = $form->getInput('show_pax_pic');
             $form_input['show_pax_matriculation'] = $form->getInput('show_pax_matriculation');
             $form_input['show_pax_username'] = $form->getInput('show_pax_username');
+            $form_input['ilias_root_uri'] = $form->getInput('ilias_root_uri');
             
             $success = $this->config->saveSEBConf($form_input);
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -48,8 +48,8 @@ show_pax_pic#:#Bilder der Teilnehmer/innen anzeigen
 show_pax_pic_info#:#Wenn diese Option aktiviert ist, wird während des Tests rechts oben ein Foto der Teilnehmerin/des Teilnehmers angezeigt. Bedingt, dass Profilbilder auf der ILIAS-Installation vorhanden sind.
 show_pax_username#:#Benutzernamen der Teilnehmer/innen anzeigen
 show_pax_username_info#:#Wenn diese Option aktiviert ist, wird während des Tests im Kopf der Benutzername der Teilnehmerin/des Teilnehmers angezeigt.
-allow_protocol_change#:Protokoll-Wechsel in Anfrage-URL zulassen
-allow_protocol_change_info#:Wenn diese Option aktiviert ist, wird ein Wechsel zwischen HTTP und HTTPS in den geprüften Anfrage-URLs zugelassen. Dies kann bei bestimmten Proxy-Server-Konfigurationen notwendig sein.
+ilias_root_uri#:ILIAS Root-URI
+ilias_root_uri_info#:Diese URI kann angepasst werden, falls die ILIAS-URI (Protokoll/Host/Port) von der Anfrage-URL des SEB abweicht (z.B. in Proxy-Konfigurationen). Der Wert kann gelöscht werden, um ihn auf die URI des ILIAS-Systems zurückzusetzen.
 title_delete_sessions_table#:#Die folgenden Session(s) werden entfernt und die entsprechenden Teilnehmer/innen ausgeloggt.
 title_sessions_table#:#Aktuelle Sessions von Test-Teilnehmer/innen
 title_settings_form#:#Objekt-spezifische Keys

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -48,6 +48,8 @@ show_pax_pic#:#Bilder der Teilnehmer/innen anzeigen
 show_pax_pic_info#:#Wenn diese Option aktiviert ist, wird während des Tests rechts oben ein Foto der Teilnehmerin/des Teilnehmers angezeigt. Bedingt, dass Profilbilder auf der ILIAS-Installation vorhanden sind.
 show_pax_username#:#Benutzernamen der Teilnehmer/innen anzeigen
 show_pax_username_info#:#Wenn diese Option aktiviert ist, wird während des Tests im Kopf der Benutzername der Teilnehmerin/des Teilnehmers angezeigt.
+allow_protocol_change#:Protokoll-Wechsel in Anfrage-URL zulassen
+allow_protocol_change_info#:Wenn diese Option aktiviert ist, wird ein Wechsel zwischen HTTP und HTTPS in den geprüften Anfrage-URLs zugelassen. Dies kann bei bestimmten Proxy-Server-Konfigurationen notwendig sein.
 title_delete_sessions_table#:#Die folgenden Session(s) werden entfernt und die entsprechenden Teilnehmer/innen ausgeloggt.
 title_sessions_table#:#Aktuelle Sessions von Test-Teilnehmer/innen
 title_settings_form#:#Objekt-spezifische Keys

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -47,6 +47,8 @@ show_pax_pic#:#Show picture of Participants
 show_pax_pic_info#:#If enabled a image of the participant is shown in the right corner of the screen. For this to work images need to be available on ILIAS.
 show_pax_username#:#Show username of Participants
 show_pax_username_info#:#If enabled the username of the participant is shown in the header
+allow_protocol_change#:Allow a protocol change in the request URL
+allow_protocol_change_info#:If enabled, a change between HTTP and HTTPS is allowed for the request URL. This might be necessary for certain proxy server configurations.
 title_delete_sessions_table#:#The following sessions will be deleted and the corresponding users will be logged out
 title_sessions_table#:#Current Sessions for Test-Participants
 title_settings_form#:#Object-specific Keys

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -8,7 +8,7 @@ activate_session_control_info_disabled#:#This function can only be activated if 
 allow_object_keys#:#Activate object-specific keys
 allow_object_keys_info#:#If you check this box users who can edit the settings of a course can also set test-specific keys.
 browser_access#:#Browser Access
-browser_access_info#:#If set to "seb" and "Role Deny" is set to "all expect Admin" only requests from a detected SEB are passed to ILIAS.<br />If set to "none" access is denied for <strong>ALL</strong> browsers and <strong>ALL</strong> users expected admin role, so be careful!
+browser_access_info#:#If set to "seb" and "Role Deny" is set to "all except Admin" only requests from a detected SEB are passed to ILIAS.<br />If set to "none" access is denied for <strong>ALL</strong> browsers and <strong>ALL</strong> users expected admin role, so be careful!
 browser_all#:#All
 browser_kiosk#:#Browser for Kiosk Skin
 browser_kiosk_info#:#The browser to  activate the kiosk skin. If no role for kiosk mode is set above, the setting is ignored.
@@ -30,12 +30,12 @@ req_header#:#Request Header
 req_header_info#:#The key name of the request header field. PHP prefixes the header fields automatically with "HTTP_" alters "-" to "_" and set the whole string to uppercase. <br />The original request field name in the seb config is "X-SafeExamBrowser-RequestHash".
 role_all_except_admin#:#All except Admin
 role_deny#:#Role Deny
-role_deny_info#:#If set to "all expect Admin" all other roles are blocked and only passed with a detected SEB.
+role_deny_info#:#If set to "all except Admin" all other roles are blocked and only passed with a detected SEB.
 role_kiosk#:#Role for Kiosk Skin
 role_kiosk_info#:#The roles to  activate the kiosk skin
 role_none#:#None
 save_failure#:#Save failed!
-save_success#:#Save succesful
+save_success#:#Save successful
 seb_keys#:#SEB Keys
 seb_keys_info#:#The comma seperated keys for SEB detection as a value of the request header above. WARNING! After setting up one or more seb keys and safe the configs, the default behavior is blocking the access from ALL users expect admins, if they don't use a secure browser!
 sessions_deleted#:#The sessions where deleted.
@@ -47,10 +47,10 @@ show_pax_pic#:#Show picture of Participants
 show_pax_pic_info#:#If enabled a image of the participant is shown in the right corner of the screen. For this to work images need to be available on ILIAS.
 show_pax_username#:#Show username of Participants
 show_pax_username_info#:#If enabled the username of the participant is shown in the header
-allow_protocol_change#:Allow a protocol change in the request URL
-allow_protocol_change_info#:If enabled, a change between HTTP and HTTPS is allowed for the request URL. This might be necessary for certain proxy server configurations.
+ilias_root_uri#:ILIAS Root-URI
+ilias_root_uri_info#:This URI can be adapted if the system's protocol/host/port is different than that of the request URL sent by SEB (e.g. in certain proxy configurations). If the value is deleted, it will be reset to the URI of the ILIAS system.
 title_delete_sessions_table#:#The following sessions will be deleted and the corresponding users will be logged out
 title_sessions_table#:#Current Sessions for Test-Participants
 title_settings_form#:#Object-specific Keys
 url_salt#:#URL Salt (experimental)
-url_salt_info#:#If "URL Salt" is checked then the seb key is joined with the request url and sended as sha1-256 hash. Please ask your systemadmin for details.
+url_salt_info#:#If "URL Salt" is checked then the seb key is joined with the request url and sent as sha1-256 hash. Please ask your systemadmin for details.

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -163,4 +163,11 @@ if ($ilDB->query("SELECT * FROM ui_uihk_seb_conf WHERE name='show_pax_username'"
     );
     $ilDB->insert('ui_uihk_seb_conf', $data);
 }
+if ($ilDB->query("SELECT * FROM ui_uihk_seb_conf WHERE name='ilias_root_uri'")->numRows() == 0) {
+    $data = array(
+        'name' => array('text', 'ilias_root_uri'),
+        'value' => array('text', '')
+    );
+    $ilDB->insert('ui_uihk_seb_conf', $data);
+}
 ?>


### PR DESCRIPTION
In certain proxy configurations, the request URL used by SEB to create a hash of the exam keys might be changed from HTTPS to HTTP when it reaches the ILIAS server. In this case, the check for correct keys might fail. This PR adds a new option to ignore this change and check the keys against valid hashes for both URL variants.

@kergomard Please have a look. This is in response to the behaviour of the plugin in combination with our test server.