### PR TITLE
AccessChecker: Fix error in URL construction

### DIFF
--- a/classes/class.ilSEBAccessChecker.php
+++ b/classes/class.ilSEBAccessChecker.php
@@ -249,7 +249,7 @@ class ilSEBAccessChecker
 
         if ($this->conf->getIliasRootUri() !== '') {
             $root_uri = new \ILIAS\Data\URI($this->conf->getIliasRootUri());
-            $protocol = $root_uri->getHost();
+            $protocol = $root_uri->getSchema();
             $port = $root_uri->getPort();
             $host = $root_uri->getHost();
         }


### PR DESCRIPTION
This fixes an error in the construction of the request URL (when a dedicated root URI is set in config).