### PR TITLE
GlobalScreen: Fix return type definition for MetabarModification

### DIFF
--- a/classes/class.ilSEBGlobalScreenModificationProvider.php
+++ b/classes/class.ilSEBGlobalScreenModificationProvider.php
@@ -61,7 +61,7 @@ class ilSEBGlobalScreenModificationProvider extends AbstractModificationPluginPr
     public function getMetaBarModification(CalledContexts $screen_context_stack) : ?MetaBarModification
     {
         return $this->dic->globalScreen()->layout()->factory()->metabar()->withModification(
-            function (MetaBar $current = null) : MetaBar {
+            function (MetaBar $current = null) : ?MetaBar {
                 $empty_metabar = $current->withClearedEntries();
                 if (!$this->isTestRunning()) {
                     $empty_metabar = $this->withLanguageAndLogout($empty_metabar);


### PR DESCRIPTION
AbstractLayoutModification needs the return type to be nullable, otherwise an exception is thrown with the current release_7 of ILIAS.